### PR TITLE
Centrality Bug Fix

### DIFF
--- a/src/centrality/algorithms.rs
+++ b/src/centrality/algorithms.rs
@@ -32,7 +32,7 @@ where
     Ty: GraphConstructor<A, W>,
 {
     if !<Ty as GraphConstructor<A, W>>::is_directed() {
-        return out_degree_centrality(&graph);
+        return out_degree_centrality(graph);
     }
     let n = graph.node_count();
     let mut degree = vec![0; n];
@@ -54,7 +54,7 @@ where
     Ty: GraphConstructor<A, W>,
 {
     if !<Ty as GraphConstructor<A, W>>::is_directed() {
-        return out_degree_centrality(&graph);
+        return out_degree_centrality(graph);
     }
     let n = graph.node_count();
     let mut cent = vec![0.0; n];

--- a/src/community/algorithms.rs
+++ b/src/community/algorithms.rs
@@ -344,10 +344,7 @@ fn compute_edge_betweenness(
 ///
 /// # Returns
 /// A vector of weight vectors, where each weight vector is the embedding for the nth node.
-pub fn spectral_embeddings<A, W, Ty>(
-    graph: &BaseGraph<A, W, Ty>,
-    k: usize
-) -> Vec<Vec<f64>>
+pub fn spectral_embeddings<A, W, Ty>(graph: &BaseGraph<A, W, Ty>, k: usize) -> Vec<Vec<f64>>
 where
     W: Copy + PartialOrd + Into<f64> + From<u8>,
     Ty: GraphConstructor<A, W>,
@@ -376,7 +373,6 @@ where
     }
     embedding
 }
-
 
 /// Production-level Spectral Clustering.
 ///

--- a/tests/test_community_algorithms.rs
+++ b/tests/test_community_algorithms.rs
@@ -101,7 +101,6 @@ fn test_spectral_embeddings() {
     }
 }
 
-
 #[test]
 fn test_spectral_clustering() {
     let graph = sample_graph();


### PR DESCRIPTION
[issue](https://github.com/habedi/graphina/issues/11)

## Bug Example

When calculating the degree centrality of an undirected graph, the "degree centrality", "in degree centrality", and "out degree centrality" should be the same, since there are not directionality.

```rust
use graphina::centrality::algorithms::*;
use graphina::core::types::*;

fn main() {
    // Create a new undirected graph
    let mut graph: BaseGraph<i32, f64, Undirected> = Graph::new();

    // Add nodes and edges to the graph
    let ids = (0..4).map(|i| graph.add_node(i)).collect::<Vec<_>>();

    let edges = [
        // Quad
        (0, 1),
        (1, 2),
        (2, 3),
        (3, 0),
        // cross
        (0, 2),
        (1, 3),
    ];

    for (s, d) in edges {
        graph.add_edge(ids[s], ids[d], 1.0);
    }

    println!("Degree     : {:?}", degree_centrality(&graph));
    println!("In-Degree  : {:?}", in_degree_centrality(&graph));
    println!("Out-Degree : {:?}", out_degree_centrality(&graph));
}
```
However the result is not as expected.
```
Degree     : [4.0, 4.0, 5.0, 5.0]
In-Degree  : [1.0, 1.0, 2.0, 2.0]
Out-Degree : [3.0, 3.0, 3.0, 3.0]
```

## Bug source
This happens because the code to calculate in-degree and out-degree is as follow.
```rust
// ...
// Out–degree.
for (node, _) in graph.nodes() {
    degree[node.index()] += graph.neighbors(node).count();
}
// ...

// ...
// In–degree.
for (_u, v, _w) in graph.edges() {
    degree[v.index()] += 1;
}
// ...
```
### for out degree centrality
for an undirected graph, the number of `neighbors` is the number of outgoing edge, which already the degree, that's why `out_degree_centrality` is corrected.
### for in degree centrality
for an undirected graph, the calculation only consider the edge that has the current node as destination, that's why the result of in-degree centrality is equal to the number of edges that has the node as destination
### for total degree centrality
it sum the in-degree and out-degree, which cause the incorrected result.


## Fix (Patch)
When calculating degree centrality and in-degree centrality, first check whether the input graph is directed, if it's undirected graph, if so, use the out-degree instead.
```rust
pub fn degree_centrality<A, W, Ty>(graph: &BaseGraph<A, W, Ty>) -> Vec<f64>
where
    W: Copy,
    Ty: GraphConstructor<A, W>,
{
    if !<Ty as GraphConstructor<A, W>>::is_directed() {
        return out_degree_centrality(&graph);
    }
    // ...
}

/// In–degree centrality.
pub fn in_degree_centrality<A, W, Ty>(graph: &BaseGraph<A, W, Ty>) -> Vec<f64>
where
    W: Copy,
    Ty: GraphConstructor<A, W>,
{
    if !<Ty as GraphConstructor<A, W>>::is_directed() {
        return out_degree_centrality(&graph);
    }
    // ...
}
```
# Fixed Result


```
Degree     : [3.0, 3.0, 3.0, 3.0]
In-Degree  : [3.0, 3.0, 3.0, 3.0]
Out-Degree : [3.0, 3.0, 3.0, 3.0]
```

## Development Workflow
- [x] `make format`   
- [x] `make test`   
- [x] `make lint`   

## Other Fix
This is just a patch to fix the bug, there can be a more sophisticated using the type system.

---

## Extra 
## some code structure discussion, if you're open to some structural change with the library...

I'ev just start digging into the code base, but why do we need to have these type and trait?
```rust
use graphina::core::types::{
    Undirected, Directed, 
    NodeId, EdgeId,
    GraphConstructor,
    BaseGraph
};
```
[`Undirected`](https://docs.rs/petgraph/latest/petgraph/enum.Undirected.html) and [`Directed`](https://docs.rs/petgraph/latest/petgraph/enum.Directed.html) already exist in petgraph which serve the same purpose. `NodeId` and `EdgeId` provide no functionality and it's just a wrapper.

`GraphConstructor` provide the two function interface:

`fn is_directed() -> bool` :already provide by `EdgeType` trait, which both `graphina::Directed` and `graphina::Undirected` already implemented, and 

`fn new_graph() -> PetGraph<A, W, Self>`: which is used total 2 times in the codebase

- `graphina::core::types.rs` impl block of `BaseGraph`
```rust
/// Creates a new `BaseGraph`.
pub fn new() -> Self {
    Self {
        inner: Ty::new_graph(),
        // inner: PetGraph::<A, W, Ty>::with_capacity(0, 0)
        // ^^
        // this can be easily inlined
    }
}
```
- `graphina::core::types.rs` impl block of `BaseGraph<A,f64,Ty>`
```rust
pub fn convert<U>(&self) -> BaseGraph<A, U, Ty>
where
    U: From<f64> + Clone,
    A: Clone,
    Ty: GraphConstructor<A, U>,
{
    let mut new_graph = BaseGraph::<A, U, Ty> {
        inner: <Ty as GraphConstructor<A, U>>::new_graph(),
    };
    // let mut new_graph = BaseGraph::<A, U, Ty>::new()
    // ^^^
    // this should just use the new constructror function defined
    // . . .
}
```

### BaseGraph
also for the `BaseGraph`, it's just a very thin wrapper to `PetGraph`, and there are a lot of function that is just exposing the api from `PetGraph`, e.g.
```rust
pub fn remove_node(&mut self, node: NodeId) -> Option<A> {
    self.inner.remove_node(node.0)
}
``` 
if you get rid of `NodeId`, and `EdgeId` and use the `petgraph`'s `NodeIndex` and `EdgeIndex`, you can rid of a lot conversion between types, and 

1. simply impl `Deref` and `DerefMut` to expose api; Or
2. get rid of `struct BaseGraph` entirely, and work with `PetGraph` directly along side a `trait BaseGraph` for extra functionality needed.