### PR TITLE
Pagerank change return type to `NodeMap`

### DIFF
--- a/examples/centrality.rs
+++ b/examples/centrality.rs
@@ -262,6 +262,25 @@ fn closeness_centrality_impl_example() {
     }
 }
 
+fn pagerank_example() {
+    use graphina::core::types::Digraph;
+
+    use graphina::centrality::algorithms::pagerank;
+
+    let mut graph = Digraph::new();
+    let nodes = (0..5).map(|i| graph.add_node(i)).collect::<Vec<_>>();
+    let edges = [(0, 1, 1.0), (0, 2, 1.0), (1, 3, 1.0)];
+    for (s, d, w) in edges {
+        graph.add_edge(nodes[s], nodes[d], w);
+    }
+
+    let centrality = pagerank(&graph, 0.85, 1000);
+    let expected = [0.14161, 0.20180, 0.20180, 0.31315, 0.14161];
+    for (i, f) in expected.into_iter().enumerate() {
+        assert!((centrality[&nodes[i]] - f).abs() < 1e-5)
+    }
+}
+
 macro_rules! run_examples {
     ($($func:ident),* $(,)?) => {
         $(
@@ -289,5 +308,7 @@ fn main() {
         // closeness centrality
         closeness_centrality_example,
         closeness_centrality_impl_example,
+        // pagerank
+        pagerank_example,
     );
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -516,5 +516,8 @@ pub type Graph<A, W> = BaseGraph<A, W, Undirected>;
 /// This refers to the `Undirected` marker type.
 pub type GraphMarker = Undirected;
 
+/// type alias for [`HashMap`] that map [`NodeId`] to `T`
 pub type NodeMap<T> = HashMap<NodeId, T>;
+
+/// type alias for [`HashMap`] that map [`EdgeId`] to `T`
 pub type EdgeMap<T> = HashMap<EdgeId, T>;

--- a/tests/test_centrality_algorithms.rs
+++ b/tests/test_centrality_algorithms.rs
@@ -94,9 +94,9 @@ fn test_eigenvector_centrality() {
 fn test_pagerank() {
     let graph = build_test_graph_f64();
     let pr = pagerank(&graph, 0.85, 50);
-    let total: f64 = pr.iter().sum();
+    let total: f64 = pr.values().sum();
     assert!(approx_eq(total, 1.0, 1e-6));
-    for score in pr {
+    for score in pr.into_values() {
         assert!(score > 0.0);
     }
 }


### PR DESCRIPTION
# Development Workflow
- [x] `make format`
- [x] `make test`
- [x] `make lint`

# Bug Related
#21 

changed return type of `pagerank` and `pagerank_impl` to `NodeMap<f64>`, and some minor changes.

# Example
```rust
fn pagerank_example() {
    use graphina::core::types::Digraph;

    use graphina::centrality::algorithms::pagerank;

    let mut graph = Digraph::new();
    let nodes = (0..5).map(|i| graph.add_node(i)).collect::<Vec<_>>();
    let edges = [(0, 1, 1.0), (0, 2, 1.0), (1, 3, 1.0)];
    for (s, d, w) in edges {
        graph.add_edge(nodes[s], nodes[d], w);
    }

    let centrality = pagerank(&graph, 0.85, 1000);
    let expected = [0.14161, 0.20180, 0.20180, 0.31315, 0.14161];
    for (i, f) in expected.into_iter().enumerate() {
        assert!((centrality[&nodes[i]] - f).abs() < 1e-5)
    }
}
```
